### PR TITLE
feat: 요청 정보가 서버내 존재하지 않을 경우의 응답코드 수정 404 -> 400

### DIFF
--- a/backend/src/main/java/io/pentacore/backend/global/unit/exception/ErrorCode.java
+++ b/backend/src/main/java/io/pentacore/backend/global/unit/exception/ErrorCode.java
@@ -11,13 +11,12 @@ public enum ErrorCode {
     INVALID_REQUEST(400, "요청 데이터가 올바르지 않습니다."),
     INVALID_FORMAT_EMAIL(400, "이메일 형식이 올바르지 않습니다."),
     NOT_ENOUGH_STOCK(400, "재고가 부족합니다."),
+    ADMIN_NOT_FOUND(400, "존재하지 않는 관리자입니다."),
+    PRODUCT_NOT_FOUND(400, "존재하지 않는 상품입니다."),
+    ORDER_FROM_USER_NOT_FOUND(400, "사용자의 주문 내역이 존재하지 않습니다."),
+    ORDER_NOT_FOUND(400, "존재하지 않는 주문 내역입니다."),
 
     UNAUTHORIZED(401, "유효하지 않은 인증입니다."),
-
-    ADMIN_NOT_FOUND(404, "존재하지 않는 관리자입니다."),
-    PRODUCT_NOT_FOUND(404, "존재하지 않는 상품입니다."),
-    ORDER_FROM_USER_NOT_FOUND(404, "사용자의 주문 내역이 존재하지 않습니다."),
-    ORDER_NOT_FOUND(404, "존재하지 않는 주문 내역입니다."),
 
     INTERNAL_SERVER_ERROR(500, "서버 에러입니다. 서버 팀에 연락주세요!");
 

--- a/backend/src/test/java/io/pentacore/backend/OrderFailureTest.java
+++ b/backend/src/test/java/io/pentacore/backend/OrderFailureTest.java
@@ -1,6 +1,5 @@
 package io.pentacore.backend;
 
-import io.pentacore.backend.global.template.MockMvcTestBase;
 import io.pentacore.backend.global.template.UserMockMvcTestBase;
 import io.pentacore.backend.global.utils.TestPaymentDtoBuilder;
 import io.pentacore.backend.global.utils.TestProductBuilder;
@@ -50,7 +49,7 @@ public class OrderFailureTest extends UserMockMvcTestBase {
     }
     
     @Test
-    @DisplayName("존재하지 않는 상품 주문 시 404 에러")
+    @DisplayName("존재하지 않는 상품 주문 시 400 에러")
     void payNullProduct() throws Exception {
         // given
         PaymentRequestDto paymentRequestDto = TestPaymentDtoBuilder.build(
@@ -63,12 +62,12 @@ public class OrderFailureTest extends UserMockMvcTestBase {
         ResultActions resultActions = mockPerformPayment(paymentRequestDto);
 
         // then
-        resultActions.andExpect(status().isNotFound());
+        resultActions.andExpect(status().isBadRequest());
         
     }
 
     @Test
-    @DisplayName("존재하지 않는 주문 취소 시 404 에러")
+    @DisplayName("존재하지 않는 주문 취소 시 400 에러")
     void deleteRequestToNullOrder() throws Exception {
         // given
         long orderId = random.nextLong();
@@ -76,12 +75,12 @@ public class OrderFailureTest extends UserMockMvcTestBase {
         // when & then
         mockMvc.perform(
                 delete("/orders/" + orderId)
-        ).andExpect(status().isNotFound());
+        ).andExpect(status().isBadRequest());
 
     }
 
     @Test
-    @DisplayName("주어진 이메일로 주문된 내역이 존재하지 않을 경우 404 에러")
+    @DisplayName("주어진 이메일로 주문된 내역이 존재하지 않을 경우 400 에러")
     void getRequestToNullOrder() throws Exception {
         // given
         String email = "test@gmail.com";
@@ -89,7 +88,7 @@ public class OrderFailureTest extends UserMockMvcTestBase {
         // when & then
         mockMvc.perform(
                 get("/orders?email=" + email)
-        ).andExpect(status().isNotFound());
+        ).andExpect(status().isBadRequest());
 
     }
 

--- a/backend/src/test/java/io/pentacore/backend/ProductCRUDTest.java
+++ b/backend/src/test/java/io/pentacore/backend/ProductCRUDTest.java
@@ -1,21 +1,17 @@
 package io.pentacore.backend;
 
-import io.pentacore.backend.admin.domain.Admin;
 import io.pentacore.backend.global.template.AdminAuthRequiredMockMvcTestBase;
-import io.pentacore.backend.global.template.MockMvcTestBase;
 import io.pentacore.backend.product.domain.Product;
 import io.pentacore.backend.product.dto.ProductRequestDto;
 import io.pentacore.backend.product.dto.UpdateRequest;
 import io.pentacore.backend.global.utils.TestProductBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;

--- a/backend/src/test/java/io/pentacore/backend/ProductFailureTest.java
+++ b/backend/src/test/java/io/pentacore/backend/ProductFailureTest.java
@@ -1,20 +1,16 @@
 package io.pentacore.backend;
 
-import io.pentacore.backend.admin.domain.Admin;
 import io.pentacore.backend.global.template.AdminAuthRequiredMockMvcTestBase;
-import io.pentacore.backend.global.template.MockMvcTestBase;
 import io.pentacore.backend.global.utils.TestProductBuilder;
 import io.pentacore.backend.product.domain.Product;
 import io.pentacore.backend.product.dto.ProductRequestDto;
 import io.pentacore.backend.product.dto.UpdateRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import java.util.Optional;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -73,7 +69,7 @@ public class ProductFailureTest extends AdminAuthRequiredMockMvcTestBase {
     }
 
     @Test
-    @DisplayName("수정할 상품이 없을 경우 404 에러")
+    @DisplayName("수정할 상품이 없을 경우 400 에러")
     void putRequestToNullProduct() throws Exception {
         // given
         String updateRequestJson = objectMapper.writeValueAsString(
@@ -87,11 +83,11 @@ public class ProductFailureTest extends AdminAuthRequiredMockMvcTestBase {
                         .content(updateRequestJson)
                         .header("Authorization", authorizationHeader)
                         .header("Refresh", refreshToken)
-        ).andExpect(status().isNotFound());
+        ).andExpect(status().isBadRequest());
     }
 
     @Test
-    @DisplayName("삭제할 상품이 없을 경우 404 에러")
+    @DisplayName("삭제할 상품이 없을 경우 400 에러")
     void deleteRequestToNullProduct() throws Exception {
         // given
         int productId = random.nextInt(100);
@@ -101,6 +97,6 @@ public class ProductFailureTest extends AdminAuthRequiredMockMvcTestBase {
                 delete("/admin/products/" + productId)
                         .header("Authorization", authorizationHeader)
                         .header("Refresh", refreshToken)
-        ).andExpect(status().isNotFound());
+        ).andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/io/pentacore/backend/global/config/MockTestConfig.java
+++ b/backend/src/test/java/io/pentacore/backend/global/config/MockTestConfig.java
@@ -1,13 +1,9 @@
 package io.pentacore.backend.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.web.SecurityFilterChain;
 
 @TestConfiguration
 public class MockTestConfig {


### PR DESCRIPTION
## 관련 이슈

<!--- 관련 이슈 번호를 기재해주세요. ex) close #이슈번호 (or) fix #이슈번호 -->

close #87 

## 개요

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요 -->

요청 정보가 서버내 존재하지 않을 경우 기존 응답코드는 404 NotFound로 정의되었음.
이를 400 BadRequest로 변경함.